### PR TITLE
chore(deps): bump org.eclipse.jetty.version in /tenio-core

### DIFF
--- a/tenio-core/pom.xml
+++ b/tenio-core/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<io.netty.version>4.1.50.Final</io.netty.version>
-		<org.eclipse.jetty.version>9.4.29.v20200521</org.eclipse.jetty.version>
+		<org.eclipse.jetty.version>9.4.31.v20200723</org.eclipse.jetty.version>
 		<javax.servlet.version>2.5</javax.servlet.version>
 		<org.msgpack.version>0.6.12</org.msgpack.version>
 	</properties>


### PR DESCRIPTION
Bumps `org.eclipse.jetty.version` from 9.4.29.v20200521 to 9.4.31.v20200723.

Updates `jetty-server` from 9.4.29.v20200521 to 9.4.31.v20200723
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.29.v20200521...jetty-9.4.31.v20200723)

Updates `jetty-servlet` from 9.4.29.v20200521 to 9.4.31.v20200723
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.29.v20200521...jetty-9.4.31.v20200723)

Signed-off-by: dependabot[bot] <support@github.com>